### PR TITLE
Remove use of direct descendant selector. Fixes #23.

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,13 +288,13 @@ The compiled CSS:
     .o-burger--veggie { texture: smooth; }
 
     /* Veggie Burger block modifier modifies the Meat element too */
-    .o-burger--veggie > .o-burger__meat { type: lentils; }
+    .o-burger--veggie .o-burger__meat { type: lentils; }
 
     /* Veggie Burger block modifier modifies the Extra Topping element too */
-    .o-burger--veggie > .o-burger__extra-topping { ingredient: avocado; }
+    .o-burger--veggie .o-burger__extra-topping { ingredient: avocado; }
 
     /* But as hackers we couldn't resist the urge to add some Bacon back */
-    .o-burger--veggie > ._o-burger__extra-topping { ingredient: bacon; }
+    .o-burger--veggie ._o-burger__extra-topping { ingredient: bacon; }
 
     /* When the party Theme is Mexican, we make everything spicy */
     .t-mexican .o-burger { spicy: hell-yeah; }

--- a/stylesheets/_modifies-element.scss
+++ b/stylesheets/_modifies-element.scss
@@ -27,7 +27,7 @@
     $s: &; // Workaround for libsass
     $block: selector-append($s...);
 
-    $selector: selector-nest($block, '>', $selectors);
+    $selector: selector-nest($block, $selectors);
 
     $set-current: set-current-context('modifies-element', $modified-elements, $selector);
 

--- a/stylesheets/_suffix.scss
+++ b/stylesheets/_suffix.scss
@@ -20,17 +20,36 @@ $bem-suffix-namespace: '\\@' !default;
     @each $suffix in $suffixes {
         @each $sel in & {
 
-            // Checking if the selector is composed of 3 elements. If that's the case,
+            // Checking if the selector is composed of 2 elements. If that's the case,
             // we're dealing with an element being modified by a block modifier.
             // In that case, we need to add the suffix to the block too.
             // @TODO Find a better way to deal with this situation.
+            $in-element: false;
 
-                @if length($sel) == 3 {
+            @if (map-has-key($_bem-current-context, 'theme')
+             or map-has-key($_bem-current-context, 'scope')) {
+                $in-element: true;
+            }
+
+            @if length($sel) == 2 {
+                @if ($in-element) {
+                    $tmp: append((), nth($sel, 1), space);
+                    $tmp: append($tmp, nth($sel, 2), space);
+                    $sel: #{$tmp};
+                } @else {
                     $tmp: append((), nth($sel, 1) + '#{$namespace}#{$suffix}', space);
                     $tmp: append($tmp, nth($sel, 2), space);
+                    $sel: #{$tmp};
+                }
+            } @else if (length($sel) == 3) {
+                @if ($in-element) {
+                    $tmp: append((), nth($sel, 1), space);
+                    $tmp: append($tmp, nth($sel, 2) + '#{$namespace}#{$suffix}', space);
                     $tmp: append($tmp, nth($sel, 3), space);
                     $sel: #{$tmp};
                 }
+            }
+
             $s: $sel + '#{$namespace}#{$suffix}';
             $selector: append($selector, $s, 'comma');
         }

--- a/test/specs/_hack.scss
+++ b/test/specs/_hack.scss
@@ -27,7 +27,7 @@
             @include element('element');
             @include modifier('modifier') {
                 @include modifies-element('element') {
-                    @include should( expect( #{_hack()} ), to( be( '.o-block--modifier > ._o-block__element' )));
+                    @include should( expect( #{_hack()} ), to( be( '.o-block--modifier ._o-block__element' )));
                 }
             }
         }
@@ -42,7 +42,7 @@
             @include element('element2');
             @include modifier('modifier') {
                 @include modifies-element('element1', 'element2') {
-                    @include should( expect( #{_hack()} ), to( be( '.o-block--modifier > ._o-block__element1, .o-block--modifier > ._o-block__element2' )));
+                    @include should( expect( #{_hack()} ), to( be( '.o-block--modifier ._o-block__element1, .o-block--modifier ._o-block__element2' )));
                 }
             }
         }

--- a/test/specs/_modifies-element.scss
+++ b/test/specs/_modifies-element.scss
@@ -6,7 +6,7 @@
         @include block('block', 'object') {
             @include element('element');
             @include modifier('modifier') {
-                @include should( expect( #{_modifies-element('element')} ), to( be( '.o-block--modifier > .o-block__element' )));
+                @include should( expect( #{_modifies-element('element')} ), to( be( '.o-block--modifier .o-block__element' )));
             }
         }
     }
@@ -18,7 +18,7 @@
         @include block('block', 'object') {
             @include element('element1', 'element2');
             @include modifier('modifier') {
-                @include should( expect( #{_modifies-element('element1', 'element2')} ), to( be( '.o-block--modifier > .o-block__element1, .o-block--modifier > .o-block__element2' )));
+                @include should( expect( #{_modifies-element('element1', 'element2')} ), to( be( '.o-block--modifier .o-block__element1, .o-block--modifier .o-block__element2' )));
             }
         }
     }
@@ -30,7 +30,7 @@
         @include block('block', 'object') {
             @include element('element');
             @include modifier('modifier1', 'modifier2') {
-                @include should( expect( #{_modifies-element('element')} ), to( be( '.o-block--modifier1.o-block--modifier2 > .o-block__element' )));
+                @include should( expect( #{_modifies-element('element')} ), to( be( '.o-block--modifier1.o-block--modifier2 .o-block__element' )));
             }
         }
     }
@@ -42,7 +42,7 @@
         @include block('block', 'object') {
             @include element('element1', 'element2');
             @include state('state') {
-                @include should( expect( #{_modifies-element('element1', 'element2')} ), to( be( '.o-block.is-state > .o-block__element1, .o-block.is-state > .o-block__element2' )));
+                @include should( expect( #{_modifies-element('element1', 'element2')} ), to( be( '.o-block.is-state .o-block__element1, .o-block.is-state .o-block__element2' )));
             }
         }
     }
@@ -54,7 +54,7 @@
         @include block('block', 'object') {
             @include element('element1', 'element2');
             @include theme('theme') {
-                @include should( expect( #{_modifies-element('element1', 'element2')} ), to( be( '.t-theme .o-block > .o-block__element1, .t-theme .o-block > .o-block__element2' )));
+                @include should( expect( #{_modifies-element('element1', 'element2')} ), to( be( '.t-theme .o-block .o-block__element1, .t-theme .o-block .o-block__element2' )));
             }
         }
     }

--- a/test/specs/_suffix.scss
+++ b/test/specs/_suffix.scss
@@ -48,7 +48,7 @@
         @include block('block', 'object') {
             @include modifier('foo') {
                 @include modifies-element('bar') {
-                    @include should( expect( #{_suffix('large')} ), to( be( '.o-block--foo\\@large > .o-block__bar\\@large' )));
+                    @include should( expect( #{_suffix('large')} ), to( be( '.o-block--foo\\@large .o-block__bar\\@large' )));
                 }
             }
         }
@@ -63,6 +63,34 @@
             }
         }
     }
+
+    $_bem-current-context: () !global;
+
+    @include it("should generate a suffix block to element modifier within a theme") {
+        @include block('block', 'object') {
+            @include theme('foo') {
+                @include modifier('bar') {
+                    @include modifies-element('baz') {
+                        @include should( expect( _suffix('large') ), to( be( '.t-foo .o-block--bar\\@large .o-block__baz\\@large' )));
+                    }
+                }
+            }
+        }
+    }
+
+    $_bem-current-context: () !global;
+
+    // @include it("should generate a suffix block to element modifier within a scope") {
+    //     @include scope('foo') {
+    //         @include block('block', 'object') {
+    //             @include modifier('bar') {
+    //                 @include modifies-element('baz') {
+    //                     @include should( expect( _suffix('large') ), to( be( '.s-foo .o-block--bar\\@large .o-block__baz\\@large' )));
+    //                 }
+    //             }
+    //         }
+    //     }
+    // }
 
     $_bem-current-context: () !global;
 


### PR DESCRIPTION
Removing the direct descendant selector to avoid making assumptions of the structure of the markup.

The following snippet:

``` scss
@include object('foo') {
    @include element('bar') {
        /* .... */
    }
}
```

now compiles to:

``` css
.o-foo .o-foo__bar {
    /* ... */
}
```

instead of:

``` css
.o-foo > .o-foo__bar {
    /* ... */
}
```
