### PR TITLE
add default type for block

### DIFF
--- a/stylesheets/_block.scss
+++ b/stylesheets/_block.scss
@@ -55,7 +55,7 @@ $bem-block-namespaces: (
 /// @param {String} $block  - Name for the new block
 /// @param {String} $type   - Block type: (utility, object or component)
 
-@mixin block($name, $type) {
+@mixin block($name, $type: '') {
 
     // Write block selector
     @at-root #{_block($name, $type)} {


### PR DESCRIPTION
1) If set $bem-use-namespaces: false;
2) use @include block('block') {}
3) get error: <img width="1162" alt="2018-11-28 14 46 04" src="https://user-images.githubusercontent.com/2566756/49149974-99d05000-f31c-11e8-9817-d2012040f217.png">